### PR TITLE
Make ydotool optional

### DIFF
--- a/.run/LinVAM ydotool.run.xml
+++ b/.run/LinVAM ydotool.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="LinVAM ydotool" type="PythonConfigurationType" factoryName="Python">
+    <module name="LinVAM" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="linvam/main.py" />
+    <option name="PARAMETERS" value="--debug --use-ydotool" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ After installing from AUR, run ``sudo usermod -aG tty,input $USER`` to allow [ui
   - tqdm
   - vosk
 - ffmpeg
-- [ydotool](https://github.com/ReimuNotMoe/ydotool)
+- [ydotool](https://github.com/ReimuNotMoe/ydotool) (optional)
 
 #### Installation steps
 <details>
@@ -132,7 +132,7 @@ Udev is the Linux system that detects and reacts to devices getting plugged or u
 It also works with virtual devices like ``ydotool``.
 
 You also need to define new udev rules that will give needed groups permanent write access to the uinput device
-(this will give ``ydotoold`` write access and ``LinVAM`` read access).
+(this will give ``LinVAM`` and ``ydotoold`` write and read access).
 
 For easy setup, execute the ``configure-uinput-access.sh`` script from the ``scripts`` folder.
 
@@ -158,7 +158,7 @@ You can also use ``--language='languageName'`` for specifying a language. If ``-
 <details>
 <summary>Steam Deck</summary>
 
-After setting up profiles in the GUI app, you can add ``linvamrun --use-keyboard --use-mouse --profile='Profile name' -- %command%`` to the game launch options for starting the console app for listening when opening games.
+After setting up profiles in the GUI app, you can add ``linvamrun --profile='Profile name' -- %command%`` to the game launch options for starting the console app for listening when opening games.
 
 You can also use ``--language='languageName'`` for specifying a language. If ``--language`` argument is not used, app defaults to language selected in the GUI app.
 
@@ -223,5 +223,4 @@ https://alphacephei.com/vosk/adaptation
 ## Debugging if something isn't working
 You can use the following arguments with ``linvam`` or ``linvamrun`` for debugging when something isn't working:
 - ``--debug`` - prints additional info while running
-- ``--use-keyboard`` - LinVAM will try and input keyboard events directly to ``input`` instead of through ``ydotool``
-- ``--use-mouse`` - LinVAM will try and input mouse events directly to ``input`` instead of through ``ydotool``
+- ``--use-ydotool`` - LinVAM will try and input keyboard and mouse events through ``ydotool`` instead of directly to ``input`` 

--- a/linvam/linvamrun.py
+++ b/linvam/linvamrun.py
@@ -43,7 +43,7 @@ class LinVAMRun:
             self.m_profile_executor.set_enable_listening(True)
             if self.m_config[Config.OPEN_COMMANDS_FILE]:
                 # pylint: disable=consider-using-with
-                subprocess.Popen(['xdg-open', LINVAM_COMMANDS_FILE_PATH], shell=True)
+                subprocess.Popen('xdg-open ' + LINVAM_COMMANDS_FILE_PATH, shell=True)
         else:
             print('linvamrun: Profile not found, not listening...')
 

--- a/linvam/linvamrun.py
+++ b/linvam/linvamrun.py
@@ -8,7 +8,7 @@ from linvam import __version__
 from linvam.profileexecutor import ProfileExecutor
 from linvam.util import (get_config, get_language_name, save_linvamrun_run_config, delete_linvamrun_run_file,
                          init_config_folder, LINVAM_COMMANDS_FILE_PATH, read_profiles, handle_args,
-                         update_profiles_for_new_version)
+                         update_profiles_for_new_version, Config)
 
 
 class LinVAMRun:
@@ -16,12 +16,11 @@ class LinVAMRun:
         update_profiles_for_new_version()
         self.m_profile_executor = None
         self.m_config = {
-            'profileName': '',
-            'language': self.get_language_from_database(),
-            'openCommandsFile': 0,
-            'debug': 0,
-            'keyboard': 0,
-            'mouse': 0
+            Config.PROFILE_NAME: '',
+            Config.LANGUAGE: self.get_language_from_database(),
+            Config.OPEN_COMMANDS_FILE: 0,
+            Config.DEBUG: 0,
+            Config.USE_YDOTOOL: 0
         }
         init_config_folder()
         signal.signal(signal.SIGINT, signal.SIG_DFL)
@@ -29,11 +28,11 @@ class LinVAMRun:
     def start_listening(self):
         handle_args(self.m_config)
         self.m_profile_executor = ProfileExecutor(self)
-        language = self.m_config['language']
+        language = self.m_config[Config.LANGUAGE]
         self.m_profile_executor.set_language(language)
         language_name = get_language_name(language)
-        save_linvamrun_run_config('language', language_name)
-        profile_name = self.m_config['profileName']
+        save_linvamrun_run_config(Config.LANGUAGE, language_name)
+        profile_name = self.m_config[Config.PROFILE_NAME]
         if len(profile_name) == 0:
             print('linvamrun: No profile specified, not listening...')
             return
@@ -42,7 +41,7 @@ class LinVAMRun:
             self.m_profile_executor.set_profile(profile)
             save_linvamrun_run_config('profile', profile['name'])
             self.m_profile_executor.set_enable_listening(True)
-            if self.m_config['openCommandsFile']:
+            if self.m_config[Config.OPEN_COMMANDS_FILE]:
                 # pylint: disable=consider-using-with
                 subprocess.Popen(['xdg-open', LINVAM_COMMANDS_FILE_PATH], shell=True)
         else:
@@ -75,7 +74,7 @@ class LinVAMRun:
     @staticmethod
     def get_language_from_database():
         try:
-            return get_config('language')
+            return get_config(Config.LANGUAGE)
         except Exception as ex:
             print("linvamrun: failed to load selected language file: " + str(ex))
             return 'en'

--- a/linvam/main.py
+++ b/linvam/main.py
@@ -14,7 +14,7 @@ from linvam.util import (get_supported_languages, get_config, save_config, save_
                          delete_linvam_run_file, init_config_folder, read_profiles, save_profiles, copy_profiles_to_dir,
                          HOME_DIR, import_profiles_from_file, merge_profiles, get_safe_name,
                          update_profiles_for_new_version, handle_args, is_push_to_listen, get_push_to_listen_hotkey,
-                         save_push_to_listen_hotkey, save_is_push_to_listen, setup_mangohud)
+                         save_push_to_listen_hotkey, save_is_push_to_listen, setup_mangohud, Config)
 
 
 class MainWnd(QWidget):
@@ -23,9 +23,8 @@ class MainWnd(QWidget):
         update_profiles_for_new_version()
 
         self.m_config = {
-            'debug': 0,
-            'keyboard': 0,
-            'mouse': 0
+            Config.DEBUG: 0,
+            Config.USE_YDOTOOL: 0
         }
         self.m_active_profile = None
         self.keyboard_listener = None
@@ -209,7 +208,7 @@ class MainWnd(QWidget):
         return selected_profile_position
 
     def load_languages(self):
-        selected_language = get_config('language')
+        selected_language = get_config(Config.LANGUAGE)
         selected_language_position = 0
         languages = get_supported_languages()
         for position, language in enumerate(languages):
@@ -235,8 +234,8 @@ class MainWnd(QWidget):
             return
         language = self.ui.languageCbx.itemText(index)
         self.m_profile_executor.set_language(language)
-        save_config('language', language)
-        save_linvam_run_config('language', language)
+        save_config(Config.LANGUAGE, language)
+        save_linvam_run_config(Config.LANGUAGE, language)
 
     def slot_add_new_profile(self):
         w_profile_edit_wnd = ProfileEditWnd(None, self)

--- a/linvam/profileexecutor.py
+++ b/linvam/profileexecutor.py
@@ -15,7 +15,8 @@ from linvam.mouse import ButtonEvent
 from linvam.mouse import nixmouse as _os_mouse
 from linvam.soundfiles import SoundFiles
 from linvam.util import (get_language_code, get_voice_packs_folder_path, get_language_name, YDOTOOLD_SOCKET_PATH,
-                         KEYS_SPLITTER, save_to_commands_file, is_push_to_listen, get_push_to_listen_hotkey, Command)
+                         KEYS_SPLITTER, save_to_commands_file, is_push_to_listen, get_push_to_listen_hotkey, Command,
+                         Config)
 
 
 def _execute_external_command(cmd_name, is_async):
@@ -40,7 +41,7 @@ class ProfileExecutor(threading.Thread):
         self.m_cmd_threads = {}
         self.p_parent = p_parent
         self.ydotoold = None
-        if not self.p_parent.m_config['keyboard'] or not self.p_parent.m_config['mouse']:
+        if self.p_parent.m_config[Config.USE_YDOTOOL]:
             self.start_ydotoold()
 
         self.m_stream = None
@@ -118,7 +119,7 @@ class ProfileExecutor(threading.Thread):
     def _init_stream(self):
         if self.recognizer is None:
             return
-        if self.p_parent.m_config['debug']:
+        if self.p_parent.m_config[Config.DEBUG]:
             callback = self.listen_callback_debug
         else:
             callback = self.listen_callback
@@ -269,10 +270,10 @@ class ProfileExecutor(threading.Thread):
                 self._scroll_mouse(p_action)
 
     def _move_mouse(self, action):
-        if self.p_parent.m_config['mouse']:
-            self._move_mouse_mouse(action)
-        else:
+        if self.p_parent.m_config[Config.USE_YDOTOOL]:
             self._move_mouse_ydotool(action)
+        else:
+            self._move_mouse_mouse(action)
 
     @staticmethod
     def _move_mouse_mouse(p_action):
@@ -289,10 +290,10 @@ class ProfileExecutor(threading.Thread):
         self._execute_ydotool_command(command)
 
     def _scroll_mouse(self, action):
-        if self.p_parent.m_config['mouse']:
-            self._scroll_mouse_mouse(action)
-        else:
+        if self.p_parent.m_config[Config.USE_YDOTOOL]:
             self._scroll_mouse_ydotool(action)
+        else:
+            self._scroll_mouse_mouse(action)
 
     @staticmethod
     def _scroll_mouse_mouse(p_action):
@@ -303,10 +304,10 @@ class ProfileExecutor(threading.Thread):
         self._execute_ydotool_command(command)
 
     def _click_mouse_key(self, action):
-        if self.p_parent.m_config['mouse']:
-            self._click_mouse_key_mouse(action)
-        else:
+        if self.p_parent.m_config[Config.USE_YDOTOOL]:
             self._click_mouse_key_ydotool(action)
+        else:
+            self._click_mouse_key_mouse(action)
 
     @staticmethod
     def _click_mouse_key_mouse(p_action):
@@ -364,7 +365,7 @@ class ProfileExecutor(threading.Thread):
     def _execute_ydotool_command(self, command):
         if self.ydotoold is not None:
             os.system('env YDOTOOL_SOCKET=' + YDOTOOLD_SOCKET_PATH + ' ydotool ' + command)
-            if self.p_parent.m_config['debug']:
+            if self.p_parent.m_config[Config.DEBUG]:
                 print('Executed ydotool command: ' + command)
         else:
             print('ydotoold daemon not running')
@@ -437,10 +438,10 @@ class ProfileExecutor(threading.Thread):
         self.m_sound.play(sound_file)
 
     def _press_key(self, action):
-        if self.p_parent.m_config['keyboard']:
-            self._press_key_keyboard(action)
-        else:
+        if self.p_parent.m_config[Config.USE_YDOTOOL]:
             self._press_key_ydotool(action)
+        else:
+            self._press_key_keyboard(action)
 
     def _press_key_ydotool(self, action):
         events = str(action['key_events']).replace(KEYS_SPLITTER, ' ')

--- a/linvam/util.py
+++ b/linvam/util.py
@@ -33,6 +33,13 @@ class Command(StrEnum):
     MOUSE_CLICK_ACTION = 'mouse click action'
     MOUSE_SCROLL_ACTION = 'mouse scroll action'
 
+class Config(StrEnum):
+    PROFILE_NAME = 'profile_name'
+    LANGUAGE = 'language'
+    OPEN_COMMANDS_FILE = 'open_commands_file'
+    DEBUG = 'debug'
+    USE_YDOTOOL = 'use_ydotool'
+
 def handle_args(config):
     if len(sys.argv) == 1:
         return
@@ -43,17 +50,15 @@ def handle_args(config):
             arg_split = argument.split('=')
             match arg_split[0]:
                 case '--debug':
-                    config['debug'] = 1
-                case '--use-keyboard':
-                    config['keyboard'] = 1
-                case '--use-mouse':
-                    config['mouse'] = 1
+                    config[Config.DEBUG] = 1
+                case '--use-ydotool':
+                    config[Config.USE_YDOTOOL] = 1
                 case '--profile':
-                    config['profileName'] = arg_split[1]
+                    config[Config.PROFILE_NAME] = arg_split[1]
                 case '--language':
-                    config['language'] = arg_split[1]
+                    config[Config.LANGUAGE] = arg_split[1]
                 case '--open-commands':
-                    config['openCommandsFile'] = 1
+                    config[Config.OPEN_COMMANDS_FILE] = 1
         except Exception as ex:
             print('Error parsing argument ' + str(argument) + ": " + str(ex))
 
@@ -317,11 +322,11 @@ def save_config(config_name, value):
 
 
 def get_default_config_values():
-    return json.dumps({'profile': '', 'language': 'English'}, indent=4, ensure_ascii=False)
+    return json.dumps({'profile': '', Config.LANGUAGE: 'English'}, indent=4, ensure_ascii=False)
 
 
 def get_default_run_config_values():
-    return json.dumps({'profile': '', 'language': ''}, indent=4, ensure_ascii=False)
+    return json.dumps({'profile': '', Config.LANGUAGE: ''}, indent=4, ensure_ascii=False)
 
 
 def get_voice_packs_folder_path():


### PR DESCRIPTION
- Use keyboard and mouse modules to input as default
- Use ``ydotool`` when ``--use-ydotool`` argument is used